### PR TITLE
feat: implement user creation endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.postgresql</groupId>
@@ -66,6 +70,7 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/src/main/java/com/pablo_dev9/budgee_be/controller/UserController.java
+++ b/src/main/java/com/pablo_dev9/budgee_be/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.pablo_dev9.budgee_be.controller;
+
+import com.pablo_dev9.budgee_be.model.dto.UserReqDto;
+import com.pablo_dev9.budgee_be.model.dto.UserResDto;
+import com.pablo_dev9.budgee_be.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public UserResDto postUser(@Valid @RequestBody final UserReqDto userReqDto) {
+        return userService.createUser(userReqDto);
+    }
+
+    @GetMapping("/{userId}")
+    public UserResDto getUserById(@PathVariable final Long userId) {
+        return userService.fetchUserById(userId);
+    }
+}
+

--- a/src/main/java/com/pablo_dev9/budgee_be/model/dto/UserReqDto.java
+++ b/src/main/java/com/pablo_dev9/budgee_be/model/dto/UserReqDto.java
@@ -1,0 +1,27 @@
+package com.pablo_dev9.budgee_be.model.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@Getter
+@RequiredArgsConstructor
+public class UserReqDto {
+    @NotBlank
+    @Size(min = 3, max = 50)
+    private final String username;
+
+    @NotBlank
+    @Email
+    private final String email;
+
+    @NotBlank
+    @Size(min = 6)
+    private final String password;
+
+    private final String avatarUrl;
+}

--- a/src/main/java/com/pablo_dev9/budgee_be/model/dto/UserResDto.java
+++ b/src/main/java/com/pablo_dev9/budgee_be/model/dto/UserResDto.java
@@ -1,0 +1,15 @@
+package com.pablo_dev9.budgee_be.model.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@Getter
+@RequiredArgsConstructor
+public class UserResDto {
+    private final Long id;
+    private final String username;
+    private final String email;
+    private final String avatarUrl;
+}

--- a/src/main/java/com/pablo_dev9/budgee_be/model/entity/User.java
+++ b/src/main/java/com/pablo_dev9/budgee_be/model/entity/User.java
@@ -13,6 +13,7 @@ import java.util.List;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pablo_dev9/budgee_be/repository/UserRepository.java
+++ b/src/main/java/com/pablo_dev9/budgee_be/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.pablo_dev9.budgee_be.repository;
+
+import com.pablo_dev9.budgee_be.model.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/pablo_dev9/budgee_be/service/UserService.java
+++ b/src/main/java/com/pablo_dev9/budgee_be/service/UserService.java
@@ -1,0 +1,31 @@
+package com.pablo_dev9.budgee_be.service;
+
+import com.pablo_dev9.budgee_be.exceptions_handler.exceptions.not_found.UserNotFoundException;
+import com.pablo_dev9.budgee_be.model.dto.UserReqDto;
+import com.pablo_dev9.budgee_be.model.dto.UserResDto;
+import com.pablo_dev9.budgee_be.model.entity.User;
+import com.pablo_dev9.budgee_be.repository.UserRepository;
+import com.pablo_dev9.budgee_be.service.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+
+    public UserResDto createUser(final UserReqDto userReqDto) {
+        final User user = userMapper.reqDtoToUser(userReqDto);
+        final User savedUser = userRepository.save(user);
+        return userMapper.userToResDto(savedUser);
+    }
+
+    public UserResDto fetchUserById(final Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+        return userMapper.userToResDto(user);
+    }
+
+
+}

--- a/src/main/java/com/pablo_dev9/budgee_be/service/mapper/UserMapper.java
+++ b/src/main/java/com/pablo_dev9/budgee_be/service/mapper/UserMapper.java
@@ -1,0 +1,30 @@
+package com.pablo_dev9.budgee_be.service.mapper;
+
+import com.pablo_dev9.budgee_be.model.dto.UserReqDto;
+import com.pablo_dev9.budgee_be.model.dto.UserResDto;
+import com.pablo_dev9.budgee_be.model.entity.User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserMapper {
+
+    public User reqDtoToUser(final UserReqDto userReqDto) {
+        return User.builder()
+                .username(userReqDto.getUsername())
+                .password(userReqDto.getPassword())
+                .email(userReqDto.getEmail())
+                .avatarUrl(userReqDto.getAvatarUrl())
+                .build();
+
+    }
+
+    public UserResDto userToResDto(final User user) {
+        return UserResDto.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .avatarUrl(user.getAvatarUrl())
+                .build();
+    }
+
+}


### PR DESCRIPTION
- Added User entity with JPA annotations and best practice structure.
- Created UserRepository extending JpaRepository for DB operations.
- Developed UserService to handle business logic for user creation.
- Implemented UserMapper to map between User, UserReqDto, and UserResDto.
- Defined UserReqDto for user creation requests (excluding auto-generated ID).
- Defined UserResDto for clean API responses, omitting sensitive fields.
- Added UserController with POST /user endpoint for creating users.
- Applied constructor injection via @RequiredArgsConstructor.
- Ensured clean separation of concerns and code readability.